### PR TITLE
Do not treat 404's as success, detect XML parse errors and don't die.

### DIFF
--- a/protocol.js
+++ b/protocol.js
@@ -343,10 +343,17 @@
       xhr.setRequestHeader('Authorization', this._getAuth());
 
       xhr.onload = function() {
-        if (xhr.status === 401 || xhr.status === 403)
+        if (xhr.status !== 200)
           return aCallback(new HttpError(xhr.statusText, xhr.status));
 
-        let doc = new DOMParser().parseFromString(xhr.responseText, 'text/xml');
+        let doc;
+        try {
+          doc = new DOMParser().parseFromString(xhr.responseText, 'text/xml');
+        }
+        catch (ex) {
+          return aCallback(new AutodiscoverDomainError(
+            'Badly formed XML: ' + ex));
+        }
 
         function getNode(xpath, rel) {
           return doc.evaluate(xpath, rel, nsResolver,


### PR DESCRIPTION
Autodiscover on yahoo.com fails for me (or at least gets very unhappy) because we are trying to interpret the 404 HTML page as XML.  This suggests there are 2 problems here:
- We should really only be trying to parse 200 results.  We may need to support other weird things like 451 of course, but we don't want to handle random errors.
- We need to handle XML parse failures cleanly by catching the exception.  (I have a similar change for gelam).

I am seeing this for unit tests for gelam where we don't have the explicit local mapping for yahoo.com.  I expect this is breaking us on other account types too.
